### PR TITLE
chore: update Figma link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # flepRename
-Here is the Figma link [here](https://www.figma.com/files/team/1415646284020645478/project/284608243/FLEPMate?fuid=1415646279831081677)
+Here is the Figma link [here](https://www.figma.com/design/EOM0DPxmM1FzGwxFeoItsE/Untitled?node-id=0-1&m=dev)


### PR DESCRIPTION
Previous link was the project's link, now changed to the template's link